### PR TITLE
Add organization fields to user registration and profile management

### DIFF
--- a/MetaGap/app/forms.py
+++ b/MetaGap/app/forms.py
@@ -3,7 +3,8 @@
 from django import forms
 from django.contrib.auth.forms import UserChangeForm, UserCreationForm
 from django.contrib.auth.models import User
-from .models import SampleGroup
+
+from .models import OrganizationProfile, SampleGroup
 
 class SearchForm(forms.Form):
     query = forms.CharField(
@@ -23,6 +24,13 @@ class CustomUserCreationForm(UserCreationForm):
         required=True,
         widget=forms.TextInput(
             attrs={"class": "form-control", "placeholder": "Username"}
+        ),
+    )
+    organization_name = forms.CharField(
+        required=False,
+        label="Organization Name",
+        widget=forms.TextInput(
+            attrs={"class": "form-control", "placeholder": "Organization"}
         ),
     )
     password1 = forms.CharField(
@@ -45,9 +53,30 @@ class CustomUserCreationForm(UserCreationForm):
     def save(self, commit=True):
         user = super().save(commit=False)
         user.email = self.cleaned_data["email"]
+        organization_name = self.cleaned_data.get("organization_name", "").strip()
+
         if commit:
             user.save()
+            self.save_m2m()
+            OrganizationProfile.objects.update_or_create(
+                user=user,
+                defaults={"organization_name": organization_name or None},
+            )
+        else:
+            # Store the organization name so it can be accessed after saving the instance.
+            self._pending_organization_name = organization_name
         return user
+
+    def save_m2m(self):
+        super().save_m2m()
+        # Ensure that the organization profile is saved if save() was called with commit=False.
+        if hasattr(self, "_pending_organization_name") and self.instance.pk:
+            organization_name = self._pending_organization_name.strip()
+            OrganizationProfile.objects.update_or_create(
+                user=self.instance,
+                defaults={"organization_name": organization_name or None},
+            )
+            del self._pending_organization_name
 
 class SampleGroupForm(forms.ModelForm):
     class Meta:
@@ -67,24 +96,60 @@ class ImportDataForm(forms.Form):
 
 class EditProfileForm(UserChangeForm):
     password = None  # Exclude password field
+    organization_name = forms.CharField(
+        required=False,
+        label="Organization Name",
+        widget=forms.TextInput(
+            attrs={"class": "form-control", "placeholder": "Organization"}
+        ),
+    )
 
     class Meta:
         model = User
-        fields = ('username', 'email', 'first_name', 'last_name')
+        fields = ("username", "email", "first_name", "last_name")
         widgets = {
-            'username': forms.TextInput(attrs={'class': 'form-control'}),
-            # Add widgets for other fields
+            "username": forms.TextInput(attrs={"class": "form-control"}),
+            "first_name": forms.TextInput(attrs={"class": "form-control"}),
+            "last_name": forms.TextInput(attrs={"class": "form-control"}),
+            "email": forms.EmailInput(attrs={"class": "form-control"}),
         }
+
+    field_order = ("username", "email", "first_name", "last_name", "organization_name")
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        organization_profile = getattr(self.instance, "organization_profile", None)
+        if organization_profile:
+            self.fields["organization_name"].initial = organization_profile.organization_name
+
+    def save(self, commit=True):
+        user = super().save(commit=False)
+        organization_name = self.cleaned_data.get("organization_name", "").strip()
+        if commit:
+            user.save()
+            self.save_m2m()
+            if self.instance.pk:
+                OrganizationProfile.objects.update_or_create(
+                    user=self.instance,
+                    defaults={"organization_name": organization_name or None},
+                )
+        else:
+            self._pending_organization_name = organization_name
+        return user
+
+    def save_m2m(self):
+        super().save_m2m()
+        if hasattr(self, "_pending_organization_name") and self.instance.pk:
+            organization_name = self._pending_organization_name.strip()
+            OrganizationProfile.objects.update_or_create(
+                user=self.instance,
+                defaults={"organization_name": organization_name or None},
+            )
+            del self._pending_organization_name
 
 class DeleteAccountForm(forms.Form):
     confirm = forms.BooleanField(
         required=True,
         label="I confirm that I want to delete my account.",
-    )
-
-class ImportDataForm(forms.Form):
-    data_file = forms.FileField(
-        required=True,
-        widget=forms.ClearableFileInput(attrs={'class': 'form-control'}),
-        help_text='Upload a VCF file.'
+        widget=forms.CheckboxInput(attrs={"class": "form-check-input"}),
     )

--- a/MetaGap/app/templates/confirm_delete.html
+++ b/MetaGap/app/templates/confirm_delete.html
@@ -4,11 +4,22 @@
 
 {% block content %}
 <div class="container mt-5">
-	<h2>Are you sure you want to delete your account?</h2>
-	<form method="post">
-		{% csrf_token %}
-		<button type="submit" class="btn btn-danger">Yes, Delete My Account</button>
-		<a href="{% url 'profile' %}" class="btn btn-secondary">Cancel</a>
-	</form>
+        <h2>Are you sure you want to delete your account?</h2>
+        <form method="post" novalidate>
+                {% csrf_token %}
+                <div class="form-check my-3">
+                        {{ form.confirm }}
+                        <label class="form-check-label" for="{{ form.confirm.id_for_label }}">{{ form.confirm.label }}</label>
+                        {% if form.confirm.errors %}
+                        <div class="invalid-feedback d-block">
+                                {% for error in form.confirm.errors %}
+                                {{ error }}
+                                {% endfor %}
+                        </div>
+                        {% endif %}
+                </div>
+                <button type="submit" class="btn btn-danger">Yes, Delete My Account</button>
+                <a href="{% url 'profile' %}" class="btn btn-secondary ms-2">Cancel</a>
+        </form>
 </div>
 {% endblock %}

--- a/MetaGap/app/templates/edit_profile.html
+++ b/MetaGap/app/templates/edit_profile.html
@@ -4,7 +4,7 @@
 
 {% block content %}
 <div class="container mt-5">
-	<h2>Edit Profile</h2>
-	{% include 'form_template.html' with form=form %}
+        <h2>Edit Profile</h2>
+        {% include 'form_template.html' with form=form submit_button_label="Save Changes" %}
 </div>
 {% endblock %}

--- a/MetaGap/app/templates/profile.html
+++ b/MetaGap/app/templates/profile.html
@@ -4,19 +4,34 @@
 
 {% block content %}
 <div class="container mt-5">
-	<h2>Your Profile</h2>
-	<p><strong>Username:</strong> {{ user.username }}</p>
-	<p><strong>Email:</strong> {{ user.email }}</p>
-	<hr>
-	{% with form_title="Import Data" %}
-	{% include 'form_template.html' with form=import_form %}
-	{% endwith %}
-	<hr>
-	<h3>Export Data</h3>
-	<a href="{% url 'home' %}" class="btn btn-success">Export Data</a>
-	<hr>
-	<h3>Account Settings</h3>
-	<a href="{% url 'home' %}" class="btn btn-primary">Edit Profile</a>
-	<a href="{% url 'home' %}" class="btn btn-danger">Delete Account</a>
+        <h2>Your Profile</h2>
+        <p><strong>Username:</strong> {{ user.username }}</p>
+        <p><strong>Email:</strong> {{ user.email }}</p>
+        {% if organization_profile %}
+        <p><strong>Organization:</strong> {{ organization_profile.organization_name|default:"Not provided" }}</p>
+        {% endif %}
+        <hr>
+        <h3>Import Data</h3>
+        {% include 'form_template.html' with form=import_form submit_button_label="Import" form_action=import_form_action form_enctype=import_form_enctype %}
+        <hr>
+        <h3>Sample Groups</h3>
+        {% if sample_groups %}
+        <ul class="list-group mb-4">
+                {% for group in sample_groups %}
+                <li class="list-group-item d-flex justify-content-between align-items-center">
+                        <span>{{ group.name }}</span>
+                </li>
+                {% endfor %}
+        </ul>
+        {% else %}
+        <p class="text-muted">You haven't added any sample groups yet.</p>
+        {% endif %}
+        <hr>
+        <h3>Export Data</h3>
+        <a href="{% url 'home' %}" class="btn btn-success">Export Data</a>
+        <hr>
+        <h3>Account Settings</h3>
+        <a href="{% url 'edit_profile' %}" class="btn btn-primary me-2">Edit Profile</a>
+        <a href="{% url 'delete_account' %}" class="btn btn-danger">Delete Account</a>
 </div>
 {% endblock %}

--- a/MetaGap/app/templates/signup.html
+++ b/MetaGap/app/templates/signup.html
@@ -4,8 +4,8 @@
 
 {% block content %}
 <div class="container mt-5">
-	<h2>Sign Up</h2>
-	{% csrf_token %}
-	{% include 'form_template.html' with form=form %}
+        <h2>Sign Up</h2>
+        {% include 'form_template.html' with form=form submit_button_label="Create Account" %}
 </div>
 {% endblock %}
+

--- a/MetaGap/app/urls.py
+++ b/MetaGap/app/urls.py
@@ -13,5 +13,7 @@ urlpatterns = [
     path("login/", auth_views.LoginView.as_view(template_name="login.html"), name="login"),
     path("logout/", auth_views.LogoutView.as_view(next_page="/"), name="logout"),
     path("profile/", views.ProfileView.as_view(), name="profile"),
+    path("profile/edit/", views.EditProfileView.as_view(), name="edit_profile"),
+    path("profile/delete/", views.DeleteAccountView.as_view(), name="delete_account"),
     path("import/", views.ImportDataView.as_view(), name="import_data"),
 ] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT) + static(settings.STATIC_URL, document_root=settings.STATIC_ROOT)


### PR DESCRIPTION
## Summary
- extend the custom user forms to capture and persist organization names alongside user data
- rebuild the profile view and template to show organization details, user sample groups, and data import controls
- add profile edit and account deletion flows with dedicated URLs and confirmation handling

## Testing
- python MetaGap/manage.py check

------
https://chatgpt.com/codex/tasks/task_e_68e616495c188328bd0dac00e8176134