### PR TITLE
Clean up ImportDataForm and add tests

### DIFF
--- a/MetaGap/app/forms.py
+++ b/MetaGap/app/forms.py
@@ -1,5 +1,3 @@
-# app/forms.py
-
 from django import forms
 from django.contrib.auth.forms import UserChangeForm, UserCreationForm
 from django.contrib.auth.models import User
@@ -81,10 +79,9 @@ class CustomUserCreationForm(UserCreationForm):
 class SampleGroupForm(forms.ModelForm):
     class Meta:
         model = SampleGroup
-        exclude = ['created_by']  # Exclude fields that will be set in the view
+        exclude = ['created_by']
         widgets = {
             'name': forms.TextInput(attrs={'class': 'form-control'}),
-            # Add widgets for other fields as needed
         }
 
 class ImportDataForm(forms.Form):

--- a/MetaGap/app/tests/test_forms.py
+++ b/MetaGap/app/tests/test_forms.py
@@ -1,0 +1,24 @@
+"""Tests for forms declared in :mod:`app.forms`."""
+
+from django.core.files.uploadedfile import SimpleUploadedFile
+from django.test import SimpleTestCase
+
+from app import forms
+
+
+class ImportDataFormTests(SimpleTestCase):
+    """Validate the behaviour of :class:`app.forms.ImportDataForm`."""
+
+    def test_valid_file_populates_cleaned_data(self):
+        form = forms.ImportDataForm(
+            files={"data_file": SimpleUploadedFile("variants.vcf", b"##fileformat=VCF\n")}
+        )
+
+        self.assertTrue(form.is_valid())
+        self.assertIn("data_file", form.cleaned_data)
+
+    def test_missing_file_fails_validation(self):
+        form = forms.ImportDataForm(data={})
+
+        self.assertFalse(form.is_valid())
+        self.assertIn("data_file", form.errors)


### PR DESCRIPTION
## Summary
- remove redundant scaffolding in the SampleGroup form definition so ImportDataForm is the sole import form
- add a focused test module that exercises ImportDataForm validation paths

## Testing
- python MetaGap/manage.py test app.tests.test_forms

------
https://chatgpt.com/codex/tasks/task_e_68e620bf7298832890967cd46dea72f4