### PR TITLE
Add coverage for filter searches and align field lookups

### DIFF
--- a/MetaGap/app/filters.py
+++ b/MetaGap/app/filters.py
@@ -3,6 +3,7 @@ import django_filters
 from django.db.models import Q
 from .models import AlleleFrequency, SampleGroup
 
+
 class AlleleFrequencyFilter(django_filters.FilterSet):
     query = django_filters.CharFilter(method='universal_search', label='Search')
 
@@ -12,12 +13,13 @@ class AlleleFrequencyFilter(django_filters.FilterSet):
 
     def universal_search(self, queryset, name, value):
         if value:
-            return queryset.filter(
-                Q(chromosome__icontains=value) |
-                Q(position__icontains=value) |
-                Q(allele_id__icontains=value)
-            )
+            value = value.strip()
+            filters_q = Q(chrom__icontains=value) | Q(variant_id__icontains=value)
+            if value.isdigit():
+                filters_q |= Q(pos=int(value))
+            return queryset.filter(filters_q)
         return queryset
+
 
 class SampleGroupFilter(django_filters.FilterSet):
     query = django_filters.CharFilter(method='universal_search', label='Search')
@@ -28,12 +30,16 @@ class SampleGroupFilter(django_filters.FilterSet):
 
     def universal_search(self, queryset, name, value):
         if value:
+            value = value.strip()
             return queryset.filter(
-                Q(name__icontains=value) |
-                Q(tissue__icontains=value) |
-                Q(collection_method__icontains=value) |
-                Q(storage_conditions__icontains=value) |
-                Q(time_stored__icontains=value) |
-                Q(comments__icontains=value)
+                Q(name__icontains=value)
+                | Q(tissue__icontains=value)
+                | Q(collection_method__icontains=value)
+                | Q(storage_conditions__icontains=value)
+                | Q(comments__icontains=value)
+                | Q(sample_origin__tissue__icontains=value)
+                | Q(sample_origin__collection_method__icontains=value)
+                | Q(sample_origin__storage_conditions__icontains=value)
+                | Q(sample_origin__time_stored__icontains=value)
             )
         return queryset

--- a/MetaGap/app/tests/test_filters.py
+++ b/MetaGap/app/tests/test_filters.py
@@ -1,0 +1,103 @@
+"""Tests for the filter classes defined in :mod:`app.filters`."""
+
+from django.contrib.auth.models import User
+from django.test import TestCase
+
+from app import filters
+from app.models import AlleleFrequency, SampleGroup, SampleOrigin
+
+
+class AlleleFrequencyFilterTests(TestCase):
+    """Validate the behaviour of :class:`app.filters.AlleleFrequencyFilter`."""
+
+    def setUp(self):
+        self.user = User.objects.create(username="filter-user")
+        self.sample_group = SampleGroup.objects.create(
+            name="Population A", created_by=self.user.organization_profile
+        )
+
+        self.record_chr1 = AlleleFrequency.objects.create(
+            sample_group=self.sample_group,
+            chrom="chr1",
+            pos=12345,
+            variant_id="rs123",
+            ref="A",
+            alt="T",
+        )
+        self.record_chr2 = AlleleFrequency.objects.create(
+            sample_group=self.sample_group,
+            chrom="chr2",
+            pos=54321,
+            variant_id="rs543",
+            ref="G",
+            alt="C",
+        )
+
+    def test_search_matches_chrom_field(self):
+        qs = filters.AlleleFrequencyFilter(
+            {"query": "chr1"}, queryset=AlleleFrequency.objects.all()
+        ).qs
+
+        self.assertEqual(list(qs), [self.record_chr1])
+
+    def test_search_matches_position_field(self):
+        qs = filters.AlleleFrequencyFilter(
+            {"query": "12345"}, queryset=AlleleFrequency.objects.all()
+        ).qs
+
+        self.assertEqual(list(qs), [self.record_chr1])
+
+    def test_search_matches_variant_id_field(self):
+        qs = filters.AlleleFrequencyFilter(
+            {"query": "rs543"}, queryset=AlleleFrequency.objects.all()
+        ).qs
+
+        self.assertEqual(list(qs), [self.record_chr2])
+
+
+class SampleGroupFilterTests(TestCase):
+    """Validate :class:`app.filters.SampleGroupFilter` lookups."""
+
+    def setUp(self):
+        self.user = User.objects.create(username="sample-user")
+        self.sample_origin = SampleOrigin.objects.create(
+            tissue="Kidney",
+            collection_method="Biopsy",
+            storage_conditions="Frozen",
+            time_stored="2 years",
+        )
+        self.group = SampleGroup.objects.create(
+            name="Kidney Cohort",
+            created_by=self.user.organization_profile,
+            tissue="Kidney",
+            collection_method="Biopsy",
+            storage_conditions="Frozen",
+            sample_origin=self.sample_origin,
+        )
+        self.other_group = SampleGroup.objects.create(
+            name="Control Cohort",
+            created_by=self.user.organization_profile,
+            tissue="Blood",
+            collection_method="Draw",
+        )
+
+    def test_search_matches_direct_tissue_field(self):
+        qs = filters.SampleGroupFilter(
+            {"query": "Kidney"}, queryset=SampleGroup.objects.all()
+        ).qs
+
+        self.assertEqual(list(qs), [self.group])
+
+    def test_search_matches_direct_collection_method_field(self):
+        qs = filters.SampleGroupFilter(
+            {"query": "Biopsy"}, queryset=SampleGroup.objects.all()
+        ).qs
+
+        self.assertEqual(list(qs), [self.group])
+
+    def test_search_matches_nested_sample_origin_time_stored(self):
+        qs = filters.SampleGroupFilter(
+            {"query": "2 years"}, queryset=SampleGroup.objects.all()
+        ).qs
+
+        self.assertEqual(list(qs), [self.group])


### PR DESCRIPTION
## Summary
- add targeted tests covering the universal search behaviour of the allele frequency and sample group filters
- exercise sample group search lookups for direct fields and nested sample origin metadata
- update the filter implementations to query the correct model fields and relations

## Testing
- python MetaGap/manage.py test app.tests.test_filters *(fails: Conflicting migrations detected in existing app migrations)*

------
https://chatgpt.com/codex/tasks/task_e_68e62e4044648328ade3e16a8b2cf195