### PR TITLE
Add tests for SampleGroupForm organization profile assignment

### DIFF
--- a/MetaGap/app/forms.py
+++ b/MetaGap/app/forms.py
@@ -97,7 +97,13 @@ class SampleGroupForm(forms.ModelForm):
         if sample_group.created_by_id is None:
             if self.user is None:
                 raise ValueError("SampleGroupForm.save() requires a user when creating a sample group.")
-            sample_group.created_by = self.user
+            try:
+                organization_profile = self.user.organization_profile
+            except OrganizationProfile.DoesNotExist as exc:
+                raise ValueError(
+                    "SampleGroupForm.save() requires the user to have an organization profile."
+                ) from exc
+            sample_group.created_by = organization_profile
 
         if commit:
             sample_group.save()

--- a/MetaGap/app/tests/test_forms.py
+++ b/MetaGap/app/tests/test_forms.py
@@ -1,7 +1,8 @@
 """Tests for forms declared in :mod:`app.forms`."""
 
 from django.core.files.uploadedfile import SimpleUploadedFile
-from django.test import SimpleTestCase
+from django.contrib.auth.models import User
+from django.test import SimpleTestCase, TestCase
 
 from app import forms
 
@@ -22,3 +23,39 @@ class ImportDataFormTests(SimpleTestCase):
 
         self.assertFalse(form.is_valid())
         self.assertIn("data_file", form.errors)
+
+
+class SampleGroupFormTests(TestCase):
+    """Tests for :class:`app.forms.SampleGroupForm`."""
+
+    def test_save_with_commit_true_assigns_organization_profile(self):
+        user = User.objects.create_user("creator", "creator@example.com", "secret")
+        form = forms.SampleGroupForm(data={"name": "Test Group"}, user=user)
+
+        self.assertTrue(form.is_valid())
+
+        sample_group = form.save()
+
+        self.assertIsNotNone(sample_group.pk)
+        self.assertEqual(sample_group.created_by, user.organization_profile)
+
+    def test_save_with_commit_false_assigns_organization_profile(self):
+        user = User.objects.create_user("creator", "creator@example.com", "secret")
+        form = forms.SampleGroupForm(data={"name": "Deferred Group"}, user=user)
+
+        self.assertTrue(form.is_valid())
+
+        sample_group = form.save(commit=False)
+
+        self.assertIsNone(sample_group.pk)
+        self.assertEqual(sample_group.created_by, user.organization_profile)
+
+    def test_missing_user_raises_value_error(self):
+        form = forms.SampleGroupForm(data={"name": "Nameless"})
+
+        self.assertTrue(form.is_valid())
+
+        with self.assertRaisesMessage(
+            ValueError, "SampleGroupForm.save() requires a user when creating a sample group."
+        ):
+            form.save()


### PR DESCRIPTION
## Summary
- add comprehensive SampleGroupForm tests covering commit=True and commit=False behaviours
- ensure the form assigns the user's organization profile and raises helpful errors when requirements are not met

## Testing
- `python manage.py test app.tests.test_forms.SampleGroupFormTests` *(fails: CommandError: Conflicting migrations detected; multiple leaf nodes in the migration graph)*

------
https://chatgpt.com/codex/tasks/task_e_68e62e45e60c8328912f8d78de88dc88