### PR TITLE
Enable manual editing of sample group metadata

### DIFF
--- a/MetaGap/app/forms.py
+++ b/MetaGap/app/forms.py
@@ -104,6 +104,21 @@ class SampleGroupForm(forms.ModelForm):
     def __init__(self, *args, **kwargs):
         self.user = kwargs.pop("user", None)
         super().__init__(*args, **kwargs)
+        text_like_widgets = (
+            forms.TextInput,
+            forms.EmailInput,
+            forms.NumberInput,
+            forms.URLInput,
+            forms.PasswordInput,
+            forms.Textarea,
+        )
+        select_widgets = (forms.Select, forms.SelectMultiple)
+        for field in self.fields.values():
+            widget = field.widget
+            if isinstance(widget, text_like_widgets):
+                widget.attrs.setdefault("class", "form-control")
+            elif isinstance(widget, select_widgets):
+                widget.attrs.setdefault("class", "form-select")
 
     class Meta:
         model = SampleGroup

--- a/MetaGap/app/templates/profile.html
+++ b/MetaGap/app/templates/profile.html
@@ -20,6 +20,8 @@
                 {% for group in sample_groups %}
                 <li class="list-group-item d-flex justify-content-between align-items-center">
                         <span>{{ group.name }}</span>
+                        <a class="btn btn-sm btn-outline-primary"
+                           href="{% url 'sample_group_edit' group.pk %}">Edit</a>
                 </li>
                 {% endfor %}
         </ul>

--- a/MetaGap/app/templates/sample_group_form.html
+++ b/MetaGap/app/templates/sample_group_form.html
@@ -1,0 +1,38 @@
+{% extends "layout.html" %}
+
+{% block title %}Edit Sample Group - MetaGaP{% endblock %}
+
+{% block content %}
+<div class="container mt-4">
+        <h2 class="mb-3">Edit Sample Group</h2>
+        <p class="text-muted">Update the descriptive metadata for this cohort. Changes will be immediately reflected in search results.</p>
+        <form method="post" novalidate>
+                {% csrf_token %}
+                {% if form.non_field_errors %}
+                <div class="alert alert-danger" role="alert">
+                        {% for error in form.non_field_errors %}
+                        {{ error }}
+                        {% endfor %}
+                </div>
+                {% endif %}
+                {% for field in form %}
+                <div class="mb-3">
+                        {{ field.label_tag }}
+                        {% if field.help_text %}
+                        <small class="form-text text-muted">{{ field.help_text }}</small>
+                        {% endif %}
+                        {{ field }}
+                        {% if field.errors %}
+                        {% for error in field.errors %}
+                        <div class="invalid-feedback" style="display: block;">{{ error }}</div>
+                        {% endfor %}
+                        {% endif %}
+                </div>
+                {% endfor %}
+                <div class="d-flex gap-2">
+                        <button type="submit" class="btn btn-primary">Save Changes</button>
+                        <a href="{% url 'profile' %}" class="btn btn-outline-secondary">Cancel</a>
+                </div>
+        </form>
+</div>
+{% endblock %}

--- a/MetaGap/app/urls.py
+++ b/MetaGap/app/urls.py
@@ -15,5 +15,10 @@ urlpatterns = [
     path("profile/", views.ProfileView.as_view(), name="profile"),
     path("profile/edit/", views.EditProfileView.as_view(), name="edit_profile"),
     path("profile/delete/", views.DeleteAccountView.as_view(), name="delete_account"),
+    path(
+        "profile/sample-groups/<int:pk>/edit/",
+        views.SampleGroupUpdateView.as_view(),
+        name="sample_group_edit",
+    ),
     path("import/", views.ImportDataView.as_view(), name="import_data"),
 ] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT) + static(settings.STATIC_URL, document_root=settings.STATIC_ROOT)


### PR DESCRIPTION
## Summary
- add a dedicated update view, route, and template so organisations can edit sample group metadata after import
- wire the edit action into the profile dashboard and enhance the SampleGroupForm with bootstrap-friendly widgets
- cover the workflow with view tests that guard permissions and successful updates

## Testing
- python manage.py test *(fails: migration app.0012_merge_20250304_0001 references missing parent)*

------
https://chatgpt.com/codex/tasks/task_e_68e640925a7483288ca8a4b803aa67c4