### PR TITLE
Ensure navbar toggler icon renders without Font Awesome

### DIFF
--- a/MetaGap/app/static/app/css/styles.css
+++ b/MetaGap/app/static/app/css/styles.css
@@ -6,3 +6,8 @@ body {
 }
 
 /* Other custom styles */
+
+/* Ensure navbar toggler icon is visible when using Bootstrap/MDB markup */
+.navbar-light .navbar-toggler-icon {
+        background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 30 30'%3e%3cpath stroke='rgba(0, 0, 0, 0.5)' stroke-linecap='round' stroke-miterlimit='10' stroke-width='2' d='M4 7h22M4 15h22M4 23h22'/%3e%3c/svg%3e");
+}

--- a/MetaGap/app/templates/base.html
+++ b/MetaGap/app/templates/base.html
@@ -7,10 +7,16 @@
 	<meta charset="UTF-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 	<title>{% block title %}MetaGaP{% endblock %}</title>
-	<!-- MDB5 CSS -->
-	<link href="https://cdnjs.cloudflare.com/ajax/libs/mdb-ui-kit/6.2.0/mdb.min.css"
-	      rel="stylesheet" />
-	<!-- Custom CSS -->
+        <!-- MDB5 CSS -->
+        <link href="https://cdnjs.cloudflare.com/ajax/libs/mdb-ui-kit/6.2.0/mdb.min.css"
+              rel="stylesheet" />
+        <!-- Font Awesome Icons -->
+        <link rel="stylesheet"
+              href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css"
+              integrity="sha512-p1CmS8G8Jz1Ih2lIO6KzHTqJchp9NNygSQkptFd03w5i1aRhj9IRoY4h4npv7ITmU7pYj5QW1C4Jr3QX+ykW2w=="
+              crossorigin="anonymous"
+              referrerpolicy="no-referrer" />
+        <!-- Custom CSS -->
 	<link rel="stylesheet" href="{% static 'app/css/styles.css' %}">
 	{% block extra_head %}{% endblock %}
 </head>

--- a/MetaGap/app/templates/layout.html
+++ b/MetaGap/app/templates/layout.html
@@ -7,15 +7,15 @@
 	<nav class="navbar navbar-expand-lg navbar-light bg-light">
 		<div class="container-fluid">
 			<a class="navbar-brand" href="{% url 'home' %}">MetaGaP</a>
-			<button class="navbar-toggler"
-			        type="button"
-			        data-mdb-toggle="collapse"
-			        data-mdb-target="#navbarNav"
-			        aria-controls="navbarNav"
-			        aria-expanded="false"
-			        aria-label="Toggle navigation">
-				<i class="fas fa-bars"></i>
-			</button>
+                        <button class="navbar-toggler"
+                                type="button"
+                                data-mdb-toggle="collapse"
+                                data-mdb-target="#navbarNav"
+                                aria-controls="navbarNav"
+                                aria-expanded="false"
+                                aria-label="Toggle navigation">
+                                <span class="navbar-toggler-icon"></span>
+                        </button>
 			<div class="collapse navbar-collapse" id="navbarNav">
 				<ul class="navbar-nav ms-auto">
 					<li class="nav-item">


### PR DESCRIPTION
## Summary
- add Font Awesome stylesheet to the base template so icon classes resolve automatically
- refactor the navbar toggler to use the built-in Bootstrap/MDB markup and provide a CSS fallback for the hamburger icon

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e6553cc5ac83288adc44a333fbed27