### PR TITLE
Preserve table headers alongside filters

### DIFF
--- a/MetaGap/app/static/app/css/styles.css
+++ b/MetaGap/app/static/app/css/styles.css
@@ -6,3 +6,19 @@ body {
 }
 
 /* Other custom styles */
+
+.datatable-header-filter {
+        display: flex;
+        flex-direction: column;
+        align-items: stretch;
+        gap: 0.25rem;
+        min-width: 6rem;
+}
+
+.datatable-header-label {
+        color: #212529;
+}
+
+.datatable-header-select {
+        width: 100%;
+}

--- a/MetaGap/app/templates/results.html
+++ b/MetaGap/app/templates/results.html
@@ -34,13 +34,20 @@ $(document).ready(function() {
         initComplete: function () {
             this.api().columns().every(function () {
                 var column = this;
-                // Create a select dropdown for each column header
-                var select = $('<select><option value="">All</option></select>')
-                    .appendTo($(column.header()).empty())
+                var header = $(column.header());
+                var headerText = header.text().trim();
+                header.empty();
+
+                var wrapper = $('<div class="datatable-header-filter"></div>');
+                var label = $('<div class="datatable-header-label fw-semibold small"></div>').text(headerText);
+                var select = $('<select class="form-select form-select-sm datatable-header-select"><option value="">All</option></select>')
                     .on('change', function () {
                         var val = $.fn.dataTable.util.escapeRegex($(this).val());
                         column.search(val ? '^' + val + '$' : '', true, false).draw();
                     });
+                wrapper.append(label);
+                wrapper.append(select);
+                header.append(wrapper);
                 // Populate the dropdown with unique values from the column
                 column.data().unique().sort().each(function (d) {
                     select.append('<option value="'+d+'">'+d+'</option>');


### PR DESCRIPTION
## Summary
- capture the original DataTables header text and render it above each column filter dropdown
- add styling so the new header/filter stack remains legible and aligned within the table

## Testing
- `python MetaGap/manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68e6553bedcc83288cbfccd2c3cc7b15