### PR TITLE
Add Bootstrap-based theme toggle

### DIFF
--- a/MetaGap/app/static/js/theme.js
+++ b/MetaGap/app/static/js/theme.js
@@ -1,0 +1,83 @@
+const THEME_STORAGE_KEY = 'metagap-theme';
+const LIGHT_THEME = 'light';
+const DARK_THEME = 'dark';
+
+const getStoredTheme = () => localStorage.getItem(THEME_STORAGE_KEY);
+
+const storeTheme = (theme) => {
+    localStorage.setItem(THEME_STORAGE_KEY, theme);
+};
+
+const getPreferredTheme = () => {
+    const storedTheme = getStoredTheme();
+    if (storedTheme) {
+        return storedTheme;
+    }
+
+    return window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches
+        ? DARK_THEME
+        : LIGHT_THEME;
+};
+
+const updateToggleAppearance = (theme) => {
+    const toggleButton = document.getElementById('themeToggle');
+    if (!toggleButton) {
+        return;
+    }
+
+    const lightIcon = toggleButton.querySelector('[data-icon-light]');
+    const darkIcon = toggleButton.querySelector('[data-icon-dark]');
+    const label = toggleButton.querySelector('[data-theme-label]');
+
+    if (lightIcon && darkIcon) {
+        if (theme === DARK_THEME) {
+            lightIcon.classList.add('d-none');
+            darkIcon.classList.remove('d-none');
+        } else {
+            lightIcon.classList.remove('d-none');
+            darkIcon.classList.add('d-none');
+        }
+    }
+
+    if (label) {
+        label.textContent = theme === DARK_THEME ? 'Dark' : 'Light';
+    }
+};
+
+const applyTheme = (theme) => {
+    document.documentElement.setAttribute('data-bs-theme', theme);
+    updateToggleAppearance(theme);
+};
+
+const initThemeToggle = () => {
+    const toggleButton = document.getElementById('themeToggle');
+    if (!toggleButton) {
+        return;
+    }
+
+    toggleButton.addEventListener('click', () => {
+        const currentTheme = document.documentElement.getAttribute('data-bs-theme');
+        const newTheme = currentTheme === DARK_THEME ? LIGHT_THEME : DARK_THEME;
+        applyTheme(newTheme);
+        storeTheme(newTheme);
+    });
+};
+
+document.addEventListener('DOMContentLoaded', () => {
+    const preferredTheme = getPreferredTheme();
+    applyTheme(preferredTheme);
+    initThemeToggle();
+
+    if (window.matchMedia) {
+        const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
+        mediaQuery.addEventListener('change', (event) => {
+            const storedTheme = getStoredTheme();
+            if (storedTheme) {
+                return;
+            }
+
+            const newTheme = event.matches ? DARK_THEME : LIGHT_THEME;
+            applyTheme(newTheme);
+        });
+    }
+});

--- a/MetaGap/app/templates/base.html
+++ b/MetaGap/app/templates/base.html
@@ -1,33 +1,34 @@
 <!-- app/templates/base.html -->
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" data-bs-theme="light">
 <head>
-	{% load static %}
-	{% load django_bootstrap5 %}
-	<meta charset="UTF-8">
-	<meta name="viewport" content="width=device-width, initial-scale=1.0">
-	<title>{% block title %}MetaGaP{% endblock %}</title>
-        <!-- MDB5 CSS -->
-        <link href="https://cdnjs.cloudflare.com/ajax/libs/mdb-ui-kit/6.2.0/mdb.min.css"
-              rel="stylesheet" />
-        <!-- Font Awesome Icons -->
+        {% load static %}
+        {% load django_bootstrap5 %}
+        <meta charset="UTF-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <title>{% block title %}MetaGaP{% endblock %}</title>
+        <link
+                href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css"
+                rel="stylesheet"
+                integrity="sha384-QWTKZyjpPEjISv0v3QFjqkTxJf0nPEzvFucZPovK/KMumsMdlB1zp0Qv5jCFdkg"
+                crossorigin="anonymous">
         <link rel="stylesheet"
               href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css"
               integrity="sha512-p1CmS8G8Jz1Ih2lIO6KzHTqJchp9NNygSQkptFd03w5i1aRhj9IRoY4h4npv7ITmU7pYj5QW1C4Jr3QX+ykW2w=="
               crossorigin="anonymous"
               referrerpolicy="no-referrer" />
-        <!-- Custom CSS -->
-	<link rel="stylesheet" href="{% static 'app/css/styles.css' %}">
-	{% block extra_head %}{% endblock %}
+        <link rel="stylesheet" href="{% static 'app/css/styles.css' %}">
+        <script src="{% static 'js/theme.js' %}" defer></script>
+        {% block extra_head %}{% endblock %}
 </head>
-<body>
-{% block body %}
-<!-- Content will be injected here -->
-{% endblock %}
-<!-- MDB5 JS -->
-<script type="text/javascript"
-        src="https://cdnjs.cloudflare.com/ajax/libs/mdb-ui-kit/6.2.0/mdb.min.js"></script>
-<!-- Custom JS -->
-{% block extra_scripts %}{% endblock %}
+<body class="min-vh-100 d-flex flex-column">
+        {% include "partials/theme-toggle.html" %}
+        {% block body %}
+        <!-- Content will be injected here -->
+        {% endblock %}
+        <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"
+                integrity="sha384-ENjdO4Dr2bkBIFxQpeoTz1HIcje39Wm4jDKdf19U8gI4ddQ3GYNS7NTKfAdVQSZe"
+                crossorigin="anonymous"></script>
+        {% block page_scripts %}{% endblock %}
 </body>
 </html>

--- a/MetaGap/app/templates/partials/theme-toggle.html
+++ b/MetaGap/app/templates/partials/theme-toggle.html
@@ -1,0 +1,10 @@
+<div class="position-fixed top-0 end-0 p-3">
+    <button id="themeToggle"
+            class="btn btn-outline-secondary d-flex align-items-center gap-2"
+            type="button"
+            aria-label="Toggle color theme">
+        <i class="fa-solid fa-sun" data-icon-light></i>
+        <i class="fa-solid fa-moon d-none" data-icon-dark></i>
+        <span data-theme-label>Light</span>
+    </button>
+</div>


### PR DESCRIPTION
## Summary
- load Bootstrap 5.3 from CDN and add a reusable page script block
- include a reusable toolbar partial with a theme toggle button
- add a theme script that persists the chosen Bootstrap theme via localStorage

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e6612a874c832894c90333aa45064d