### PR TITLE
Add Bootstrap navbar partial and integrate into base layout

### DIFF
--- a/MetaGap/app/templates/base.html
+++ b/MetaGap/app/templates/base.html
@@ -2,11 +2,11 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-	{% load static %}
-	{% load django_bootstrap5 %}
-	<meta charset="UTF-8">
-	<meta name="viewport" content="width=device-width, initial-scale=1.0">
-	<title>{% block title %}MetaGaP{% endblock %}</title>
+        {% load static %}
+        {% load django_bootstrap5 %}
+        <meta charset="UTF-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <title>{% block title %}MetaGaP{% endblock %}</title>
         <!-- MDB5 CSS -->
         <link href="https://cdnjs.cloudflare.com/ajax/libs/mdb-ui-kit/6.2.0/mdb.min.css"
               rel="stylesheet" />
@@ -17,10 +17,15 @@
               crossorigin="anonymous"
               referrerpolicy="no-referrer" />
         <!-- Custom CSS -->
-	<link rel="stylesheet" href="{% static 'app/css/styles.css' %}">
-	{% block extra_head %}{% endblock %}
+        <link rel="stylesheet" href="{% static 'app/css/styles.css' %}">
+        {% block extra_head %}{% endblock %}
 </head>
 <body>
+{% block header %}
+<header>
+        {% include 'partials/navbar.html' %}
+</header>
+{% endblock %}
 {% block body %}
 <!-- Content will be injected here -->
 {% endblock %}

--- a/MetaGap/app/templates/layout.html
+++ b/MetaGap/app/templates/layout.html
@@ -1,55 +1,30 @@
 <!-- app/templates/layout.html -->
 {% extends 'base.html' %}
 
-{% block body %}
-<header>
-	<!-- Navigation Bar -->
-        <nav class="navbar navbar-expand-lg navbar-light bg-white shadow-sm fixed-top">
-		<div class="container-fluid">
-			<a class="navbar-brand" href="{% url 'home' %}">MetaGaP</a>
-                        <button class="navbar-toggler"
-                                type="button"
-                                data-mdb-toggle="collapse"
-                                data-mdb-target="#navbarNav"
-                                aria-controls="navbarNav"
-                                aria-expanded="false"
-                                aria-label="Toggle navigation">
-                                <span class="navbar-toggler-icon"></span>
-                        </button>
-			<div class="collapse navbar-collapse" id="navbarNav">
-				<ul class="navbar-nav ms-auto">
-					<li class="nav-item">
-						<a class="nav-link" href="{% url 'about' %}">About</a>
-					</li>
-					<li class="nav-item">
-						<a class="nav-link" href="{% url 'contact' %}">Contact</a>
-					</li>
-					{% include 'loginpartial.html' %}
-				</ul>
-			</div>
-		</div>
-	</nav>
-</header>
+{% block header %}
+        {{ block.super }}
+{% endblock %}
 
+{% block body %}
 <!-- Breadcrumbs -->
 {% block breadcrumbs %}
 <nav aria-label="breadcrumb">
-	<ol class="breadcrumb m-3">
-		<li class="breadcrumb-item">
-			<a href="{% url 'home' %}">Home</a>
-		</li>
-		{% block breadcrumb_items %}
-		<!-- Additional breadcrumb items can be added here -->
-		{% endblock %}
-	</ol>
+        <ol class="breadcrumb m-3">
+                <li class="breadcrumb-item">
+                        <a href="{% url 'home' %}">Home</a>
+                </li>
+                {% block breadcrumb_items %}
+                <!-- Additional breadcrumb items can be added here -->
+                {% endblock %}
+        </ol>
 </nav>
 {% endblock %}
 
 <!-- Main Content -->
 <main role="main" class="container my-4 main-content">
-	{% block content %}
-	<!-- Page-specific content will be injected here -->
-	{% endblock %}
+        {% block content %}
+        <!-- Page-specific content will be injected here -->
+        {% endblock %}
 </main>
 
 <!-- Footer -->

--- a/MetaGap/app/templates/partials/navbar.html
+++ b/MetaGap/app/templates/partials/navbar.html
@@ -1,0 +1,64 @@
+<nav class="navbar navbar-expand-lg navbar-light bg-white border-bottom shadow-sm" aria-label="Main navigation">
+    <div class="container-fluid">
+        <a class="navbar-brand" href="{% url 'home' %}">MetaGaP</a>
+        <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#primaryNavbar" aria-controls="primaryNavbar" aria-expanded="false" aria-label="Toggle navigation">
+            <span class="navbar-toggler-icon"></span>
+        </button>
+        <div class="collapse navbar-collapse" id="primaryNavbar">
+            <ul class="navbar-nav me-auto mb-2 mb-lg-0">
+                <li class="nav-item">
+                    <a class="nav-link" href="{% url 'about' %}">About</a>
+                </li>
+                <li class="nav-item">
+                    <a class="nav-link" href="{% url 'contact' %}">Contact</a>
+                </li>
+                {% if user.is_authenticated %}
+                <li class="nav-item">
+                    <a class="nav-link" href="{% url 'search_results' %}">Search</a>
+                </li>
+                <li class="nav-item">
+                    <a class="nav-link" href="{% url 'import_data' %}">Import Data</a>
+                </li>
+                {% endif %}
+                {% if user.is_superuser %}
+                <li class="nav-item">
+                    <a class="nav-link" href="{% url 'admin:index' %}">Admin</a>
+                </li>
+                {% endif %}
+            </ul>
+            <ul class="navbar-nav ms-auto mb-2 mb-lg-0">
+                {% if user.is_superuser %}
+                <li class="nav-item">
+                    <a class="nav-link" href="{% url 'profile' %}">Profile</a>
+                </li>
+                <li class="nav-item">
+                    <form method="post" action="{% url 'logout' %}" class="d-inline">
+                        {% csrf_token %}
+                        <button type="submit" class="btn btn-link nav-link">Logout</button>
+                    </form>
+                </li>
+                {% elif user.is_authenticated %}
+                <li class="nav-item">
+                    <a class="nav-link" href="{% url 'profile' %}">Profile</a>
+                </li>
+                <li class="nav-item">
+                    <form method="post" action="{% url 'logout' %}" class="d-inline">
+                        {% csrf_token %}
+                        <button type="submit" class="btn btn-link nav-link">Logout</button>
+                    </form>
+                </li>
+                {% else %}
+                <li class="nav-item">
+                    <a class="nav-link" href="{% url 'login' %}">Login</a>
+                </li>
+                <li class="nav-item">
+                    <a class="nav-link" href="{% url 'signup' %}">Sign Up</a>
+                </li>
+                {% endif %}
+            </ul>
+            <div class="d-flex align-items-center gap-2 ms-lg-3 theme-toggle-slot" role="presentation">
+                <!-- Theme toggle slot -->
+            </div>
+        </div>
+    </div>
+</nav>


### PR DESCRIPTION
## Summary
- add a reusable Bootstrap 5 navbar partial with menu states for guests, authenticated users, and superusers
- include the navbar from a new header block in the base template and simplify the layout template to rely on it

## Testing
- python manage.py check

------
https://chatgpt.com/codex/tasks/task_e_68e6612be3a88328b20d8eb1eb1bb4c5