### PR TITLE
Harden merged VCF validation

### DIFF
--- a/MetaGap/MetagapUserCode/tests/test_validate_merged_vcf.py
+++ b/MetaGap/MetagapUserCode/tests/test_validate_merged_vcf.py
@@ -1,0 +1,29 @@
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+MODULE_PATH = Path(__file__).resolve().parents[2] / "MetagapUserCode" / "test_merge_vcf.py"
+
+
+def load_user_module():
+    spec = importlib.util.spec_from_file_location("user_test_merge_vcf", MODULE_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_validate_merged_vcf_missing_info_triggers_exit(tmp_path):
+    module = load_user_module()
+
+    vcf_content = """##fileformat=VCFv4.2
+##reference=GRCh38
+##INFO=<ID=NS,Number=1,Type=Integer,Description=\"Number of Samples With Data\">
+#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO
+1\t1000\trs1\tA\tC\t.\tPASS\t.
+"""
+    vcf_path = tmp_path / "missing_info.vcf"
+    vcf_path.write_text(vcf_content)
+
+    with pytest.raises(SystemExit):
+        module.validate_merged_vcf(str(vcf_path))


### PR DESCRIPTION
## Summary
- add helpers to validate merged VCF INFO field structure and bail out on malformed records
- ensure INFO parsing errors propagate as critical failures during merged VCF validation
- add pytest coverage for a merged VCF record missing required INFO content

## Testing
- pytest MetaGap/MetagapUserCode/tests/test_validate_merged_vcf.py

------
https://chatgpt.com/codex/tasks/task_e_68e6773f8a188328b2e2ab90c518bccb