### PR TITLE
Refine search results template layout

### DIFF
--- a/MetaGap/app/templates/results.html
+++ b/MetaGap/app/templates/results.html
@@ -60,22 +60,19 @@
     </script>
 {% endblock %}
 
-{% block content %}
-<div class="container mt-5">
-    <h2>Search Results</h2>
-
 {% block breadcrumbs %}
 {% include 'partials/breadcrumbs.html' with breadcrumb_title='Search Results' %}
 {% endblock %}
 
 {% block content %}
-<h2 class="mb-4">Search Results</h2>
-<form method="get" action="{% url 'search_results' %}" class="row g-2 align-items-center mb-4" novalidate>
+<div class="container mt-5">
+    <h2 class="mb-4">Search Results</h2>
+    <form method="get" action="{% url 'search_results' %}" class="row g-2 align-items-center mb-4" novalidate>
         <div class="col-sm-8 col-md-6 col-lg-4">
-                {{ form.query }}
+            {{ form.query }}
         </div>
         <div class="col-auto">
-                <button type="submit" class="btn btn-primary">Search</button>
+            <button type="submit" class="btn btn-primary">Search</button>
         </div>
     </form>
 

--- a/MetaGap/app/tests/test_views.py
+++ b/MetaGap/app/tests/test_views.py
@@ -140,7 +140,7 @@ class SearchResultsViewTests(TestCase):
         sample_filter = response.context["filter"]
         self.assertIsInstance(sample_filter, SampleGroupFilter)
         self.assertEqual(sample_filter.data.get("query"), "Kidney")
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             sample_filter.qs,
             [self.kidney_group],
             transform=lambda group: group,
@@ -164,7 +164,7 @@ class SearchResultsViewTests(TestCase):
         sample_filter = response.context["filter"]
         self.assertIsInstance(sample_filter, SampleGroupFilter)
         self.assertEqual(sample_filter.data.get("query"), "")
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             sample_filter.qs.order_by("pk"),
             SampleGroup.objects.order_by("pk"),
             transform=lambda group: group,


### PR DESCRIPTION
## Summary
- restructure the search results template to use a single content block while keeping breadcrumbs separate
- update search results view tests to call Django's current `assertQuerySetEqual` helper

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68e67e9fc9dc83288b4cdf4441fdf764