### PR TITLE
Fix Font Awesome integrity hash mismatch

### DIFF
--- a/MetaGap/app/templates/base.html
+++ b/MetaGap/app/templates/base.html
@@ -14,7 +14,7 @@
         <!-- Font Awesome Icons -->
         <link rel="stylesheet"
               href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css"
-              integrity="sha512-p1CmS8G8Jz1Ih2lIO6KzHTqJchp9NNygSQkptFd03w5i1aRhj9IRoY4h4npv7ITmU7pYj5QW1C4Jr3QX+ykW2w=="
+              integrity="sha512-iecdLmaskl7CVkqkXNQ/ZH/XLlvWZOJyj7Yy7tcenmpD1ypASozpmT/E0iPtmFIB46ZmdtAc9eNBvH0H/ZpiBw=="
               crossorigin="anonymous"
               referrerpolicy="no-referrer" />
         <!-- Custom CSS -->


### PR DESCRIPTION
## Summary
- update the Font Awesome CDN link integrity hash to match the hosted resource

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e6814da99083289d9feb86a6806eb4