### PR TITLE
Add global theme toggle to base layout

### DIFF
--- a/MetaGap/app/static/app/css/styles.css
+++ b/MetaGap/app/static/app/css/styles.css
@@ -6,9 +6,32 @@
         --header-margin-offset: 1rem;
 }
 
+:root[data-bs-theme='light'] {
+        --app-body-bg: #f8f9fa;
+        --app-body-color: #212529;
+        --app-navbar-bg: #ffffff;
+        --app-navbar-border: rgba(0, 0, 0, 0.08);
+        --app-footer-bg: #f8f9fa;
+        --app-footer-color: #212529;
+        --app-toggler-icon: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 30 30'%3e%3cpath stroke='rgba(0, 0, 0, 0.5)' stroke-linecap='round' stroke-miterlimit='10' stroke-width='2' d='M4 7h22M4 15h22M4 23h22'/%3e%3c/svg%3e");
+}
+
+:root[data-bs-theme='dark'] {
+        --app-body-bg: #0f0f0f;
+        --app-body-color: #f8f9fa;
+        --app-navbar-bg: #1f1f1f;
+        --app-navbar-border: rgba(255, 255, 255, 0.12);
+        --app-footer-bg: #111111;
+        --app-footer-color: #e9ecef;
+        --app-toggler-icon: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 30 30'%3e%3cpath stroke='rgba(255, 255, 255, 0.55)' stroke-linecap='round' stroke-miterlimit='10' stroke-width='2' d='M4 7h22M4 15h22M4 23h22'/%3e%3c/svg%3e");
+}
+
 /* Add top padding to account for fixed navbar */
 body {
         padding-top: var(--header-height);
+        background-color: var(--app-body-bg);
+        color: var(--app-body-color);
+        transition: background-color 0.2s ease-in-out, color 0.2s ease-in-out;
 }
 
 main.container.my-4.main-content {
@@ -27,17 +50,47 @@ main.container.my-4.main-content {
 }
 
 .datatable-header-label {
-        color: #212529;
+        color: inherit;
 }
 
 .datatable-header-select {
         width: 100%;
 }
-header .navbar {
+
+.app-navbar {
+        --bs-navbar-color: var(--app-body-color);
+        --bs-navbar-hover-color: var(--color-primary);
+        --bs-navbar-active-color: var(--color-primary);
+        --bs-navbar-brand-color: var(--app-body-color);
+        --bs-navbar-brand-hover-color: var(--color-primary);
+        --bs-navbar-toggler-border-color: transparent;
+        background-color: var(--app-navbar-bg) !important;
+        border-bottom: 1px solid var(--app-navbar-border);
         min-height: var(--header-height);
+        transition: background-color 0.2s ease-in-out, border-color 0.2s ease-in-out;
 }
 
-/* Ensure navbar toggler icon is visible when using Bootstrap/MDB markup */
-.navbar-light .navbar-toggler-icon {
-        background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 30 30'%3e%3cpath stroke='rgba(0, 0, 0, 0.5)' stroke-linecap='round' stroke-miterlimit='10' stroke-width='2' d='M4 7h22M4 15h22M4 23h22'/%3e%3c/svg%3e");
+.app-navbar .navbar-toggler-icon {
+        background-image: var(--app-toggler-icon);
+}
+
+.app-navbar .nav-link {
+        transition: color 0.2s ease-in-out;
+}
+
+.app-navbar .nav-link.active,
+.app-navbar .nav-link:focus,
+.app-navbar .nav-link:hover {
+        color: var(--color-primary);
+}
+
+.app-footer {
+        background-color: var(--app-footer-bg);
+        color: var(--app-footer-color);
+        border-top: 1px solid var(--app-navbar-border);
+        transition: background-color 0.2s ease-in-out, color 0.2s ease-in-out, border-color 0.2s ease-in-out;
+}
+
+.theme-toggle .btn {
+        white-space: nowrap;
 }

--- a/MetaGap/app/templates/base.html
+++ b/MetaGap/app/templates/base.html
@@ -3,10 +3,8 @@
 <!DOCTYPE html>
 <html lang="en" data-bs-theme="light">
 <head>
-	{% load static %}
-	{% load django_bootstrap5 %}
-	<meta charset="UTF-8">
-	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <meta charset="UTF-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
         <title>{% block title %}{{ SITE_NAME }}{% endblock %}</title>
         <!-- MDB5 CSS -->
         <link href="https://cdnjs.cloudflare.com/ajax/libs/mdb-ui-kit/6.2.0/mdb.min.css"
@@ -22,16 +20,30 @@
         {% block datatable_head %}{% endblock %}
         {% block extra_head %}{% endblock %}
 </head>
-<body style="--color-primary: {{ SITE_COLORS.primary|default:'#1f6feb' }}; --color-secondary: {{ SITE_COLORS.secondary|default:'#2ea043' }};">
+<body class="bg-body text-body" style="--color-primary: {{ SITE_COLORS.primary|default:'#1f6feb' }}; --color-secondary: {{ SITE_COLORS.secondary|default:'#2ea043' }};">
+<div class="d-flex flex-column min-vh-100">
 {% block body %}
-<!-- Content will be injected here -->
+        <header>
+                {% include "partials/navbar.html" %}
+        </header>
+
+        <main id="main-content" role="main" class="container my-4 main-content">
+                {% block breadcrumbs %}{% endblock %}
+                {% include "partials/alerts.html" %}
+                {% block content %}{% endblock %}
+        </main>
+
+        {% include "partials/footer.html" %}
 {% endblock %}
+</div>
 <!-- MDB5 JS -->
 <script type="text/javascript"
         src="https://cdnjs.cloudflare.com/ajax/libs/mdb-ui-kit/6.2.0/mdb.min.js"></script>
 <!-- DataTables and other optional scripts -->
 {% block datatable_scripts %}{% endblock %}
 <!-- Custom JS -->
-{% block extra_scripts %}{% endblock %}
+{% block extra_scripts %}
+        <script src="{% static 'js/theme.js' %}" defer></script>
+{% endblock %}
 </body>
 </html>

--- a/MetaGap/app/templates/partials/footer.html
+++ b/MetaGap/app/templates/partials/footer.html
@@ -1,5 +1,5 @@
-<footer class="bg-light text-center text-lg-start mt-auto">
-        <div class="text-center p-3">
+<footer class="app-footer text-center text-lg-start mt-auto py-3">
+        <div class="container">
                 © {% now "Y" %} MetaGaP
         </div>
 </footer>

--- a/MetaGap/app/templates/partials/navbar.html
+++ b/MetaGap/app/templates/partials/navbar.html
@@ -1,6 +1,6 @@
-<nav class="navbar navbar-expand-lg navbar-light bg-white border-bottom shadow-sm" aria-label="Main navigation">
-  <div class="container-fluid">
-    <a class="navbar-brand" href="{% url 'home' %}">MetaGaP</a>
+<nav class="navbar navbar-expand-lg app-navbar shadow-sm fixed-top" aria-label="Main navigation">
+  <div class="container">
+    <a class="navbar-brand fw-semibold" href="{% url 'home' %}">MetaGaP</a>
 
     <button class="navbar-toggler" type="button"
             data-bs-toggle="collapse" data-bs-target="#primaryNavbar"

--- a/MetaGap/app/templates/partials/theme-toggle.html
+++ b/MetaGap/app/templates/partials/theme-toggle.html
@@ -1,10 +1,10 @@
-<div class="position-fixed top-0 end-0 p-3">
+<div class="theme-toggle">
     <button id="themeToggle"
-            class="btn btn-outline-secondary d-flex align-items-center gap-2"
+            class="btn btn-outline-secondary btn-sm d-flex align-items-center gap-2"
             type="button"
             aria-label="Toggle color theme">
         <i class="fa-solid fa-sun" data-icon-light></i>
         <i class="fa-solid fa-moon d-none" data-icon-dark></i>
-        <span data-theme-label>Light</span>
+        <span class="d-none d-sm-inline" data-theme-label>Light</span>
     </button>
 </div>


### PR DESCRIPTION
## Summary
- render the shared navbar and theme toggle from the base template so they appear on every page
- load the theme toggle script and refresh layout markup with Bootstrap structure and alerts/footer placement
- update custom styles with light/dark variables so the navbar, footer, and body respond to theme changes

## Testing
- python MetaGap/manage.py check
- Manually smoke tested pages in the browser (Playwright) to confirm the theme toggle flips data-bs-theme


------
https://chatgpt.com/codex/tasks/task_e_68e681c1dfd88328a961d749d6429eb8