### PR TITLE
Adjust footer copyright spacing and size

### DIFF
--- a/MetaGap/app/templates/partials/footer.html
+++ b/MetaGap/app/templates/partials/footer.html
@@ -1,5 +1,5 @@
-<footer class="app-footer text-center text-lg-start mt-auto py-3">
-        <div class="container">
+<footer class="app-footer text-center text-lg-start mt-auto py-4 border-top">
+        <div class="container text-muted small">
                 © {% now "Y" %} MetaGaP
         </div>
 </footer>


### PR DESCRIPTION
## Summary
- restyle the footer so the copyright text appears smaller
- add spacing and a border above the footer to separate it from the search area

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e6857ac80483288a3926f1110980a0