### PR TITLE
Restrict search results to organization records

### DIFF
--- a/MetaGap/app/tests/test_views_search_dashboard.py
+++ b/MetaGap/app/tests/test_views_search_dashboard.py
@@ -28,6 +28,12 @@ class SearchResultsViewTests(TestCase):
             password="search-pass",
             email="search@example.com",
         )
+        self.other_user = User.objects.create_user(
+            username="other_search_user",
+            password="search-pass",
+            email="other-search@example.com",
+        )
+        self.client.force_login(self.user)
 
         self.kidney_origin = SampleOrigin.objects.create(
             tissue="Kidney",
@@ -56,6 +62,13 @@ class SearchResultsViewTests(TestCase):
             sample_origin=self.liver_origin,
             bioinfo_variant_calling=self.variant_caller_b,
             created_by=self.user.organization_profile,
+        )
+        self.other_group = SampleGroup.objects.create(
+            name="External Kidney Cohort",
+            source_lab="Lab Other",
+            sample_origin=self.kidney_origin,
+            bioinfo_variant_calling=self.variant_caller_a,
+            created_by=self.other_user.organization_profile,
         )
 
         self.format = Format.objects.create(genotype="0/1")
@@ -86,6 +99,7 @@ class SearchResultsViewTests(TestCase):
             sample_group=self.kidney_group,
             chrom="1",
             pos=150,
+            variant_id="kidney-pass-1",
             ref="A",
             alt="T",
             qual=180.5,
@@ -115,6 +129,18 @@ class SearchResultsViewTests(TestCase):
             info=self.liver_info,
             format=self.format,
         )
+        self.other_variant = AlleleFrequency.objects.create(
+            sample_group=self.other_group,
+            chrom="4",
+            pos=500,
+            variant_id="external-private-1",
+            ref="T",
+            alt="C",
+            qual=110.0,
+            filter="PASS",
+            info=Info.objects.create(af="0.31", ac="7", an="40", dp="42", mq="50"),
+            format=self.format,
+        )
 
     def test_query_filters_variants_and_prioritises_columns(self) -> None:
         response = self.client.get(reverse("search_results"), {"query": "Kidney"})
@@ -123,7 +149,9 @@ class SearchResultsViewTests(TestCase):
 
         table = response.context["table"]
         records = [row.record for row in table.rows]
-        self.assertEqual(records, [self.kidney_variant_pass, self.kidney_variant_filtered])
+        self.assertEqual(
+            records, [self.kidney_variant_pass, self.kidney_variant_filtered]
+        )
 
         filterset = response.context["filter"]
         self.assertIsInstance(filterset, AlleleFrequencySearchFilter)
@@ -148,6 +176,16 @@ class SearchResultsViewTests(TestCase):
         )
         self.assertNotIn("info__additional", column_names)
         self.assertNotIn("format__payload", column_names)
+
+    def test_query_filters_by_variant_id(self) -> None:
+        response = self.client.get(
+            reverse("search_results"), {"query": "kidney-pass-1"}
+        )
+
+        self.assertEqual(response.status_code, 200)
+        table = response.context["table"]
+        records = [row.record for row in table.rows]
+        self.assertEqual(records, [self.kidney_variant_pass])
 
     def test_combined_filters_reduce_results(self) -> None:
         response = self.client.get(
@@ -201,13 +239,36 @@ class SearchResultsViewTests(TestCase):
 
         self.assertEqual(response.status_code, 200)
         table = response.context["table"]
-        self.assertEqual(len(table.rows), AlleleFrequency.objects.count())
+        self.assertEqual(
+            len(table.rows),
+            AlleleFrequency.objects.filter(
+                sample_group__created_by=self.user.organization_profile
+            ).count(),
+        )
+
+    def test_user_cannot_see_another_organization_variants(self) -> None:
+        response = self.client.get(reverse("search_results"), {"query": "External"})
+
+        self.assertEqual(response.status_code, 200)
+        table = response.context["table"]
+        records = [row.record for row in table.rows]
+        self.assertEqual(records, [])
+        self.assertNotIn(self.other_variant, records)
+
+    def test_anonymous_users_are_redirected_before_seeing_variants(self) -> None:
+        self.client.logout()
+
+        response = self.client.get(reverse("search_results"), {"query": "Kidney"})
+
+        self.assertEqual(response.status_code, 302)
+        self.assertTrue(response.url.startswith(reverse("login")))
+        self.assertNotIn("Kidney Cohort", response.content.decode())
 
     def test_search_results_use_advanced_filters_toggle(self) -> None:
         response = self.client.get(reverse("search_results"))
 
         self.assertEqual(response.status_code, 200)
-        self.assertContains(response, "data-bs-target=\"#advancedFiltersCollapse\"")
+        self.assertContains(response, 'data-bs-target="#advancedFiltersCollapse"')
         self.assertContains(response, "Advanced filters")
         self.assertNotContains(response, "filter-card-header")
 
@@ -284,7 +345,12 @@ class DashboardViewTests(TestCase):
         )
 
         self.assertEqual(recent_datasets, expected_datasets)
-        self.assertTrue(all(dataset.created_by == self.user_one.organization_profile for dataset in recent_datasets))
+        self.assertTrue(
+            all(
+                dataset.created_by == self.user_one.organization_profile
+                for dataset in recent_datasets
+            )
+        )
         self.assertLessEqual(len(recent_datasets), 6)
 
         recent_actions = response.context["recent_actions"]

--- a/MetaGap/app/views.py
+++ b/MetaGap/app/views.py
@@ -74,8 +74,8 @@ from .services.import_exceptions import (
 from .services.vcf_importer import VCFImporter
 from .tables import build_allele_frequency_table, create_dynamic_table
 
-
 logger = logging.getLogger(__name__)
+
 
 class SampleGroupTableView(ListView):
     """Display a django-tables2 listing of sample groups."""
@@ -116,11 +116,14 @@ class SampleGroupTableView(ListView):
             SampleGroup, table_name="SampleGroupTable", include_related=True
         )
         table = table_class(context["object_list"])
-        RequestConfig(self.request, paginate={"per_page": self.paginate_by}).configure(table)
+        RequestConfig(self.request, paginate={"per_page": self.paginate_by}).configure(
+            table
+        )
         context["table"] = table
         return context
 
-class SearchResultsView(SingleTableMixin, FilterView):
+
+class SearchResultsView(LoginRequiredMixin, SingleTableMixin, FilterView):
     template_name = "results.html"
     model = AlleleFrequency
     context_object_name = "allele_frequencies"
@@ -137,27 +140,36 @@ class SearchResultsView(SingleTableMixin, FilterView):
         return False
 
     def get_queryset(self):
-        base_queryset = (
-            AlleleFrequency.objects.select_related(
-                "info",
-                "format",
-                "sample_group",
-                "sample_group__reference_genome_build",
-                "sample_group__genome_complexity",
-                "sample_group__sample_origin",
-                "sample_group__material_type",
-                "sample_group__library_construction",
-                "sample_group__illumina_seq",
-                "sample_group__ont_seq",
-                "sample_group__pacbio_seq",
-                "sample_group__iontorrent_seq",
-                "sample_group__bioinfo_alignment",
-                "sample_group__bioinfo_variant_calling",
-                "sample_group__bioinfo_post_proc",
-                "sample_group__input_quality",
-                "sample_group__created_by",
-            )
+        try:
+            organization_profile = self.request.user.organization_profile
+        except ObjectDoesNotExist:
+            organization_profile = None
+
+        base_queryset = AlleleFrequency.objects.select_related(
+            "info",
+            "format",
+            "sample_group",
+            "sample_group__reference_genome_build",
+            "sample_group__genome_complexity",
+            "sample_group__sample_origin",
+            "sample_group__material_type",
+            "sample_group__library_construction",
+            "sample_group__illumina_seq",
+            "sample_group__ont_seq",
+            "sample_group__pacbio_seq",
+            "sample_group__iontorrent_seq",
+            "sample_group__bioinfo_alignment",
+            "sample_group__bioinfo_variant_calling",
+            "sample_group__bioinfo_post_proc",
+            "sample_group__input_quality",
+            "sample_group__created_by",
         )
+        if organization_profile is None:
+            base_queryset = base_queryset.none()
+        else:
+            base_queryset = base_queryset.filter(
+                sample_group__created_by=organization_profile
+            )
 
         # Instantiate the filter set manually so that we can reuse it in the template context.
         self.filterset = self.filterset_class(
@@ -260,12 +272,12 @@ def export_sample_group_variants(request, pk: int) -> HttpResponse:
     filename = slugify(sample_group.name) or f"sample-group-{sample_group.pk}"
     response = HttpResponse(content_type=content_type)
     response["Content-Disposition"] = (
-        f"attachment; filename=\"{filename}.{file_extension}\""
+        f'attachment; filename="{filename}.{file_extension}"'
     )
 
-    allele_frequencies_qs = sample_group.allele_frequencies.select_related("info").order_by(
-        "chrom", "pos", "pk"
-    )
+    allele_frequencies_qs = sample_group.allele_frequencies.select_related(
+        "info"
+    ).order_by("chrom", "pos", "pk")
     allele_frequencies = list(allele_frequencies_qs)
 
     info_field_columns = [
@@ -339,18 +351,14 @@ class DashboardView(LoginRequiredMixin, OrganizationSampleGroupMixin, TemplateVi
         context = super().get_context_data(**kwargs)
         organization_profile = self.get_organization_profile()
 
-        dataset_queryset = (
-            SampleGroup.objects.select_related("created_by", "created_by__user")
-            .order_by("-pk")
-        )
-        action_queryset = (
-            AlleleFrequency.objects.select_related(
-                "sample_group",
-                "sample_group__created_by",
-                "sample_group__created_by__user",
-            )
-            .order_by("-pk")
-        )
+        dataset_queryset = SampleGroup.objects.select_related(
+            "created_by", "created_by__user"
+        ).order_by("-pk")
+        action_queryset = AlleleFrequency.objects.select_related(
+            "sample_group",
+            "sample_group__created_by",
+            "sample_group__created_by__user",
+        ).order_by("-pk")
 
         if organization_profile is not None:
             dataset_queryset = dataset_queryset.filter(created_by=organization_profile)
@@ -410,6 +418,7 @@ class DeleteAccountView(LoginRequiredMixin, FormView):
         )
         return context
 
+
 class UserRegistrationView(CreateView):
     form_class = CustomUserCreationForm
     template_name = "signup.html"
@@ -442,9 +451,7 @@ class SampleGroupCreateView(
 
     def form_valid(self, form):
         """Associate the new sample group with the user's organization."""
-        messages.success(
-            self.request, _("Sample group created successfully.")
-        )
+        messages.success(self.request, _("Sample group created successfully."))
         return super().form_valid(form)
 
     def get_context_data(self, **kwargs):
@@ -485,9 +492,7 @@ class SampleGroupUpdateView(
         return kwargs
 
     def form_valid(self, form):
-        messages.success(
-            self.request, _("Sample group metadata updated successfully.")
-        )
+        messages.success(self.request, _("Sample group metadata updated successfully."))
         return super().form_valid(form)
 
     def get_context_data(self, **kwargs):
@@ -610,7 +615,9 @@ class SampleGroupDetailView(
                 section["items"].append(item_context)
             return section
 
-        platform_label, platform_instance = sample_group.get_active_sequencing_platform()
+        platform_label, platform_instance = (
+            sample_group.get_active_sequencing_platform()
+        )
         default_platform_label = _("Sequencing platform")
         if platform_instance is None:
             sequencing_platform_row = (default_platform_label, None, None)
@@ -670,7 +677,11 @@ class SampleGroupDetailView(
                     ),
                     (_("Sample origin"), sample_group.sample_origin, None),
                     (_("Material type"), sample_group.material_type, None),
-                    (_("Library construction"), sample_group.library_construction, None),
+                    (
+                        _("Library construction"),
+                        sample_group.library_construction,
+                        None,
+                    ),
                 ],
             ),
             build_section(
@@ -719,10 +730,7 @@ class SampleGroupDetailView(
             metadata_sections.append(
                 build_section(
                     _("Custom metadata"),
-                    [
-                        (key, value, None)
-                        for key, value in additional_metadata.items()
-                    ],
+                    [(key, value, None) for key, value in additional_metadata.items()],
                 )
             )
 
@@ -730,7 +738,6 @@ class SampleGroupDetailView(
         context["allele_frequency_table"] = table
         context["variant_table"] = table
         return context
-
 
 
 class ImportDataView(LoginRequiredMixin, OrganizationSampleGroupMixin, FormView):
@@ -807,8 +814,7 @@ class ImportDataView(LoginRequiredMixin, OrganizationSampleGroupMixin, FormView)
 
         messages.success(
             self.request,
-            _("Imported %(group)s successfully.")
-            % {"group": created_group.name},
+            _("Imported %(group)s successfully.") % {"group": created_group.name},
         )
         for warning in importer.warnings:
             self._add_warning_message(warning)
@@ -826,9 +832,7 @@ class ImportDataView(LoginRequiredMixin, OrganizationSampleGroupMixin, FormView)
             message_str = force_str(
                 _("An error occurred while importing the provided file.")
             )
-        is_generic_fallback = (
-            message_str == GENERIC_FALLBACK_VALIDATION_MESSAGE_RAW
-        )
+        is_generic_fallback = message_str == GENERIC_FALLBACK_VALIDATION_MESSAGE_RAW
         display_message = (
             force_str(GENERIC_FALLBACK_VALIDATION_MESSAGE)
             if is_generic_fallback

--- a/docs/current-website-check-tasks.md
+++ b/docs/current-website-check-tasks.md
@@ -88,11 +88,18 @@ Use this checklist to verify how MetaGap is working now from setup through the m
 
 ## 7. Search workflow checks
 
-- [ ] Open `/search/` without filters and confirm the page renders.
+Product/security policy: `/search/` is an authenticated organization-private catalogue.
+Search results must be scoped to allele-frequency records whose `sample_group.created_by`
+matches the current user's organization profile; anonymous users must be redirected to
+login and must not see private records.
+
+- [ ] Open `/search/` without filters as an authenticated user and confirm the page renders.
+- [ ] Confirm anonymous access to `/search/` redirects to login without rendering allele-frequency rows.
 - [ ] Search by variant ID.
 - [ ] Search by chromosome and position if supported by the current filters.
-- [ ] Search by sample-group or metadata keyword.
-- [ ] Confirm search results include expected allele-frequency rows.
+- [ ] Search by sample-group or metadata keyword within the current organization.
+- [ ] Confirm search results include expected allele-frequency rows for the current organization.
+- [ ] Confirm search results exclude allele-frequency rows from other organizations.
 - [ ] Confirm result table sorting works.
 - [ ] Confirm pagination or DataTables controls work.
 - [ ] Confirm the clear/reset search action works.
@@ -109,12 +116,18 @@ Use this checklist to verify how MetaGap is working now from setup through the m
 
 ## 9. Authorization and data-isolation checks
 
+Product/security policy: cross-organization public search is not allowed. `/search/` is
+private to the authenticated user's organization and must filter allele-frequency records
+through `sample_group__created_by`; this intentionally prevents user A from seeing user
+B's variants and prevents anonymous users from seeing private allele-frequency records.
+
 - [ ] Create two separate test users or organizations.
 - [ ] Create or import sample groups under each account.
 - [ ] Confirm each user only sees their own profile sample groups.
 - [ ] Attempt direct URL access to another user's sample-group detail page and confirm it is denied or returns not found.
 - [ ] Attempt direct URL access to another user's edit, delete, and export URLs and confirm access is blocked.
-- [ ] Confirm public search behavior matches the intended product policy for cross-organization visibility.
+- [ ] Confirm `/search/` redirects anonymous users to login without rendering private allele-frequency records.
+- [ ] Confirm `/search/` for user A excludes user B's variants, including keyword, variant-ID, chromosome/position, and metadata searches.
 
 ## 10. Admin checks
 


### PR DESCRIPTION
### Motivation
- Ensure `/search/` is an authenticated, organization-private catalogue so users only see allele-frequency records for their own organization and anonymous access does not expose private data. 
- Prevent accidental cross-organization data leakage by scoping search and dashboard result sets to `sample_group__created_by`.

### Description
- Require authentication for search by adding `LoginRequiredMixin` to `SearchResultsView` and scope its queryset to the current `request.user.organization_profile`, returning an empty queryset when the profile is missing.  
- Update `MetaGap/app/tests/test_views_search_dashboard.py` to add a second user/sample-group/variant and new tests for `variant_id` search, cross-organization isolation, and anonymous redirect behavior.  
- Update `docs/current-website-check-tasks.md` (sections 7 and 9) to document the product/security policy that `/search/` is organization-private and to add corresponding checklist items.  

### Testing
- Ran the focused test suite with `DEBUG=1 SECRET_KEY=test-secret python manage.py test app.tests.test_views_search_dashboard` and all tests passed (11 tests, OK).  
- Ran `DEBUG=1 SECRET_KEY=test-secret python manage.py check` and received no system-check issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0463afdb8c83288b113b86a8128a06)