### PR TITLE
Add failure report template to website checklist

### DIFF
--- a/docs/current-website-check-tasks.md
+++ b/docs/current-website-check-tasks.md
@@ -1,5 +1,24 @@
 # Current Website Check Task List
 
+## Failure report template
+
+Create a separate issue/task for every checklist `FAIL`, except for clearly related duplicates that should be linked to the same root-cause issue. Each failure report must include:
+
+- Checklist section/item
+- Severity: Blocker/Critical/Major/Minor
+- Environment/browser
+- User/account/organization used
+- Dataset/file used
+- Steps to reproduce
+- Expected result
+- Actual result
+- Logs/screenshots
+- Suspected module/path
+- Owner
+- Fix status
+
+Regression verification rule: after a fix is applied, repeat the original failed check and the nearest neighboring workflow checks in the checklist to confirm the fix and surrounding workflow still pass.
+
 Use this checklist to verify how MetaGap is working now from setup through the main website workflows. Record the date, environment, tester, browser, dataset used, and pass/fail notes for each task.
 
 ## 1. Environment and startup checks


### PR DESCRIPTION
### Motivation
- Provide a consistent, actionable failure report structure so each checklist `FAIL` yields reproducible issue data for triage. 
- Require regression verification to ensure fixes do not break neighboring workflows.

### Description
- Inserted a new `## Failure report template` section at the top of `docs/current-website-check-tasks.md` that defines a required failure report for any checklist `FAIL`.
- Enumerated required fields: Checklist section/item, Severity, Environment/browser, User/account/organization used, Dataset/file used, Steps to reproduce, Expected result, Actual result, Logs/screenshots, Suspected module/path, Owner, and Fix status.
- Added rules that each `FAIL` should become a separate issue/task (except obvious duplicates) and that regression verification must re-run the original failed check plus nearest neighboring workflow checks after a fix.

### Testing
- Ran `git diff --check` which reported no issues and completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0463b4609c8328b366773ad271bf72)