### PR TITLE
fix(ci): align push-trigger to master (was main)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: Django Tests
 on:
   push:
     branches:
-      - main
+      - master
   pull_request:
 
 jobs:


### PR DESCRIPTION
## Summary

- One-line fix: `.github/workflows/ci.yml` push-trigger `branches: [main]` → `branches: [master]`.
- Repo default branch is `master`; previous trigger never fired on push to master, silently skipping coverage gates + "Unhandled metadata key" warning annotations.
- PR-trigger was unaffected (this PR still gets full CI), so the gap was only on direct master pushes.

Source: `~/Life/Tasks/metagap-system-audit/design.md` Top-3 #1.

## Test plan

- [ ] CI runs on this PR (verifies workflow syntax still parses)
- [ ] After merge, next push to master should trigger Django Tests workflow (confirm in Actions tab)

🤖 Generated with [Claude Code](https://claude.com/claude-code)